### PR TITLE
raise Userwaning on empty data. Fixes unitas/qiime2 modules

### DIFF
--- a/multiqc/modules/qiime2/qiime2.py
+++ b/multiqc/modules/qiime2/qiime2.py
@@ -39,7 +39,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.qiime2_dada2['Total'] = defaultdict(dict)
         for f in self.find_log_files('qiime2/dada2', filehandles=True):
             parsed_data = self.parse_qiime2_dada2_export(f)
-            if parsed_data is not None:
+            if len(parsed_data) > 0:
                 for region, sample_data in parsed_data.items():
                     sample_data = self.ignore_samples(sample_data)
                     for s_name, vals in sample_data.items():
@@ -50,9 +50,9 @@ class MultiqcModule(BaseMultiqcModule):
                                 self.qiime2_dada2['Total'][s_name][k] += v
                         else:
                             self.qiime2_dada2['Total'][s_name] = vals.copy()
-        if len(self.qiime2_dada2.keys()) == 0:
+        if len(self.qiime2_dada2['Total']) == 0:
             raise UserWarning
-                
+            
         log.info("Found {} dada2 regions".format(len(self.qiime2_dada2)))
 
         self.write_data_file(self.qiime2_dada2, 'multiqc_qiime2_dada2')
@@ -146,7 +146,7 @@ class MultiqcModule(BaseMultiqcModule):
                 region_data[region][s_name] = {i:j for i, j in zip(header, els)}
         except:
             log.warn("Could not parse qiime2 metadata: '{}'".format(f['fn']))
-            return None
+            return {}
         for region, sample_data in region_data.items():
             for s_name, vals in sample_data.items():
                 keep = ['input', 'filtered', 'denoised', 'merged', 'non-chimeric']

--- a/multiqc/modules/unitas/unitas.py
+++ b/multiqc/modules/unitas/unitas.py
@@ -43,21 +43,25 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files('unitas/annotation'):
             self.parse_annotation(f)
         self.annotations = self.ignore_samples(self.annotations)
+        if len(self.annotations) == 0:
+            raise UserWarning
 
         # parse sequence length distribution from .info files
         for f in self.find_log_files('unitas/seqlen'):
             for biotype in self.biotypes:
                 match = SEQLEN_MATCH.get(biotype, lambda x: False)
                 if match(f): 
-                    print(biotype, f['fn'])
                     self.parse_seqlen(f, biotype)
         self.seqlen = self.ignore_samples(self.seqlen)
-
+        if len(self.seqlen) == 0:
+            raise UserWarning
         # parse the simplified mirna counts
         for f in self.find_log_files('unitas/mirna'):
             self.parse_mirna_simplified(f)
         self.metrics = self.ignore_samples(self.metrics)
-
+        if len(self.metrics) == 0:
+            raise UserWarning
+        
         self.unitas_general_stats()
         self.annotation_plot()
         self.seqlen_lineplot()


### PR DESCRIPTION
Many thanks to contributing to MultiQC!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things I request on pull requests (PRs).

## If this PR is _not_ a new module
 - [ ] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` has been updated
 - [ ] (optional but recommended): https://github.com/ewels/MultiQC_TestData contains test data for this change

## If this PR is for a new module
 - [ ] There is example tool output for tools in the https://github.com/ewels/MultiQC_TestData repository
 - [ ] Code is tested and works locally (including with `--lint` flag)
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
 - [ ] `docs/README.md` is updated with link to below
 - [ ] `docs/modulename.md` is created
 - [ ] Everything that can be represented with a plot instead of a table is a plot
 - [ ] Report sections have a description and help text (with `self.add_section`)
 - [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
 - [ ] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
 - [ ] Module does not do any significant computational work
